### PR TITLE
Added meta field to the state object

### DIFF
--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -11,7 +11,7 @@ export default function reducer(state = initialState, action) {
 
   if (metaType === 'response' && action.payload && action.payload.body) {
     let newState = state;
-    const { data, included } = action.payload.body;
+    const { data, included, meta } = action.payload.body;
 
     let items;
 
@@ -34,6 +34,10 @@ export default function reducer(state = initialState, action) {
         item,
       )
     ), newState);
+
+    if (meta) {
+      newState = immutable.set(newState, 'meta', meta);
+    }
 
     return newState;
   }


### PR DESCRIPTION
Pull-request according to the [issues](https://github.com/cantierecreativo/redux-bees/issues/9).
Now, if a resource object with a **meta field** was passed, this field will be **saved in the redux-state.**