### PR TITLE
@query: Do not re-fetch when a query is still in progress, and the component re-mounts.

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -22,7 +22,11 @@ export default function query(propName, apiCall, dispatcher = defaultDispatcher)
       }
 
       componentDidMount() {
-        this.fetch();
+        const { hasStarted, isLoading } = this.props.request;
+
+        if(!hasStarted && !isLoading) {
+          this.fetch();
+        }
       }
 
       componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
I was getting an infinite render loop with the existing code using `@query`.

This might be slightly related to: https://github.com/cantierecreativo/redux-bees/issues/23

