### PR TITLE
Fixed issue: where relationshipName doesn't exist on a resources Relationships getRelationships should still return

### DIFF
--- a/src/selectors.js
+++ b/src/selectors.js
@@ -33,14 +33,19 @@ export function getRelationship(state, entity, relationshipName) {
     return null;
   }
 
-  const { data } = entity.relationships[relationshipName];
+  if (!entity.relationships[relationshipName]) {
+    return null;
+  }
 
+  const { data } = entity.relationships[relationshipName];
+    
   if (Array.isArray(data)) {
     return data.map(handle => getEntity(state, handle));
   }
 
   return getEntity(state, data);
 }
+
 
 export function getRequestResult(state, apiCall, args) {
   const request = getRawRequest(state, apiCall, args);


### PR DESCRIPTION
Updated getRelationship function to return null when relationshipName is not included within relationships