### PR TITLE
Fix dispatching pending action

### DIFF
--- a/src/buildApi.js
+++ b/src/buildApi.js
@@ -67,8 +67,6 @@ export default function buildApi(endpoints, config = {}) {
         configureOptions(augmentedOptions)
       );
 
-      pendingPromises[promiseId] = req;
-
       const promise = req
         .then(afterResolve)
         .then((result) => {
@@ -83,6 +81,7 @@ export default function buildApi(endpoints, config = {}) {
 
       promise.actionName = key;
       promise.params = args;
+      pendingPromises[promiseId] = promise;
 
       return promise;
     };


### PR DESCRIPTION
Fix calling dispatch of the action, that has pending status.

Save actions instead of simple promises in `pendingPromises` collection. That change removes unnecessary dispatch of `api/undefined` actions, which causes saving `undefined` results in the store.