### PR TITLE
[BUG] Request Reducer Can't Handle id=0

### DIFF
--- a/src/reducers/requests.js
+++ b/src/reducers/requests.js
@@ -71,7 +71,7 @@ export default function reducer(state = initialState, action) {
 
       if (Array.isArray(data)) {
         normalizedData = data.map(record => ({ id: record.id, type: record.type }));
-      } else if (data && data.id) {
+      } else if (data && data.id != null) {
         normalizedData = { id: data.id, type: data.type };
       } else {
         normalizedData = null;

--- a/test/reducers/requests.js
+++ b/test/reducers/requests.js
@@ -88,6 +88,47 @@ test('requests reducer', (c) => {
     t.end();
   });
 
+  c.test('with resource that has id=0', (t) => {
+    const meta = { api: true, type: 'response', name: 'getPost', params: ['0'] };
+    const action = {
+      type: 'api/getPost/request',
+      meta,
+      payload: {
+        status: 200,
+        headers: {},
+        body: { data: [{...resource, id: 0}] }
+      },
+    };
+
+    const initialState = {
+      getPost: {
+        '["0"]': {
+          error: null,
+          isLoading: true,
+        },
+      },
+    };
+
+    const state = requestsReducer(initialState, action);
+
+    t.deepEqual(
+      state,
+      {
+        getPost: {
+          '["0"]': {
+            error: null,
+            isLoading: false,
+            response: [ { id: 0, type: 'post' } ],
+            status: 200,
+            headers: {},
+          },
+        },
+      }
+    );
+
+    t.end();
+  });
+
   c.test('with actions of type error', (t) => {
     const meta = { api: true, type: 'error', name: 'getPost', params: ['12'] };
 


### PR DESCRIPTION
Thank you so much for creating this library and all the work you put in it!

I noticed that the action listed below causes `redux-bees` to think that response is null, which is not correct – it just has `id=0`. Since, this is a fairly common use-case, I figured I'd send a PR to fix it.

<img width="1005" alt="redux-bees-error" src="https://user-images.githubusercontent.com/832496/54156931-7e3d1100-4404-11e9-9736-c7f0b1bf684b.png">
